### PR TITLE
Use MutationObserver to translate new titles on lists

### DIFF
--- a/MAL_English_Titles.user.js
+++ b/MAL_English_Titles.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MAL English Titles
-// @version      2.0
+// @version      2.0.1
 // @description  Add English Titles to various MyAnimeList pages, whilst still displaying Japanese Titles
 // @author       Animorphs
 // @grant        GM_setValue
@@ -97,11 +97,11 @@ function translate()
         let type = location.href.substring(24, 29);
         let results = document.querySelectorAll('tbody:not([style]) .data.title');
 
-        const processResults = function(results)
+        const processResults = function(tempResults)
         {
-            for (let i = 0; i < results.length; i++)
+            for (let i = 0; i < tempResults.length; i++)
             {
-                let url = results[i].children[0].href;
+                let url = tempResults[i].children[0].href;
                 let urlShort = url.slice(23);
                 let urlShortDecoded = decodeURIComponent(urlShort);
                 let id = url.split('/')[4];

--- a/MAL_English_Titles.user.js
+++ b/MAL_English_Titles.user.js
@@ -97,7 +97,7 @@ function translate()
         let type = location.href.substring(24, 29);
         let results = document.querySelectorAll('tbody:not([style]) .data.title');
 
-        const processResults = function(tempResults)
+        function processResults(tempResults)
         {
             for (let i = 0; i < tempResults.length; i++)
             {
@@ -108,9 +108,9 @@ function translate()
                 let selector = '.data.title > a[href="' + urlShortDecoded + '"]';
                 addTranslation(type, i, url, id, selector);
             }
-        };
+        }
 
-        const attachMutationObserver = function(listTable)
+        function attachMutationObserver(listTable)
         {
             new MutationObserver(function(mutationsList)
             {
@@ -127,7 +127,7 @@ function translate()
                 listTable,
                 {childList: true}
             );
-        };
+        }
 
         let table = document.querySelector('table');
 

--- a/MAL_English_Titles.user.js
+++ b/MAL_English_Titles.user.js
@@ -95,7 +95,7 @@ function translate()
     else if (location.href.includes('https://myanimelist.net/animelist') || location.href.includes('https://myanimelist.net/mangalist'))
     {
         let type = location.href.substring(24, 29);
-        let results = document.getElementsByClassName('data title');
+        let results = document.querySelectorAll('tbody:not([style]) .data.title');
 
         const processResults = function(results)
         {
@@ -110,10 +110,7 @@ function translate()
             }
         };
 
-        processResults(results);
-
-        let listTable = document.querySelector('table');
-        if (listTable)
+        const attachMutationObserver = function(listTable)
         {
             new MutationObserver(function(mutationsList)
             {
@@ -128,6 +125,35 @@ function translate()
                 });
             }).observe(
                 listTable,
+                {childList: true}
+            );
+        };
+
+        let table = document.querySelector('table');
+
+        if (results.length)
+        {
+            processResults(results);
+            attachMutationObserver(table);
+        }
+        else if (table)
+        {
+            new MutationObserver(function(mutationsList)
+            {
+                mutationsList.some(function(mutation)
+                {
+                    return Array.from(mutation.addedNodes).some(function(addedNode)
+                    {
+                        if (addedNode.tagName === 'TABLE')
+                        {
+                            processResults(addedNode.querySelectorAll('.data.title'));
+                            attachMutationObserver(addedNode);
+                            return true;
+                        }
+                    });
+                });
+            }).observe(
+                table.parentElement,
                 {childList: true}
             );
         }

--- a/MAL_English_Titles.user.js
+++ b/MAL_English_Titles.user.js
@@ -91,38 +91,21 @@ function translate()
         }
     }
 
-    // Anime List
-    else if (location.href.includes('https://myanimelist.net/animelist'))
+    // Anime List and Manga List
+    else if (location.href.includes('https://myanimelist.net/animelist') || location.href.includes('https://myanimelist.net/mangalist'))
     {
-        let results = document.getElementsByClassName('data title clearfix');
-        for (let i = 0; i < results.length; i++)
-        {
-            if (!document.getElementById('anime' + i))
-            {
-                let url = results[i].children[0].href;
-                let urlShort = url.slice(23);
-                let urlShortDecoded = decodeURIComponent(urlShort);
-                let id = url.split('/')[4];
-                let selector = '.data.title.clearfix > a[href="' + urlShortDecoded + '"]';
-                addTranslation('anime', i, url, id, selector);
-            }
-        }
-    }
-
-    // Manga List
-    else if (location.href.includes('https://myanimelist.net/mangalist'))
-    {
+        let type = location.href.substring(24, 29);
         let results = document.getElementsByClassName('data title');
         for (let i = 0; i < results.length; i++)
         {
-            if (!document.getElementById('manga' + i))
+            if (!document.getElementById(type + i))
             {
                 let url = results[i].children[0].href;
                 let urlShort = url.slice(23);
                 let urlShortDecoded = decodeURIComponent(urlShort);
                 let id = url.split('/')[4];
                 let selector = '.data.title > a[href="' + urlShortDecoded + '"]';
-                addTranslation('manga', i, url, id, selector);
+                addTranslation(type, i, url, id, selector);
             }
         }
     }

--- a/MAL_English_Titles.user.js
+++ b/MAL_English_Titles.user.js
@@ -112,7 +112,7 @@ function translate()
 
         function attachMutationObserver(listTable)
         {
-            new MutationObserver(function(mutationsList)
+            new MutationObserver(function(mutationsList, observer)
             {
                 mutationsList.forEach(function(mutation)
                 {
@@ -123,6 +123,11 @@ function translate()
                         )
                     );
                 });
+
+                if ((listTable.children.length - 1) % 150 !== 0)
+                {
+                    observer.disconnect();
+                }
             }).observe(
                 listTable,
                 {childList: true}
@@ -134,11 +139,14 @@ function translate()
         if (results.length)
         {
             processResults(results);
-            attachMutationObserver(table);
+            if (results.length === 150)
+            {
+                attachMutationObserver(table);
+            }
         }
         else if (table)
         {
-            new MutationObserver(function(mutationsList)
+            new MutationObserver(function(mutationsList, observer)
             {
                 mutationsList.some(function(mutation)
                 {
@@ -146,8 +154,13 @@ function translate()
                     {
                         if (addedNode.tagName === 'TABLE')
                         {
-                            processResults(addedNode.querySelectorAll('.data.title'));
-                            attachMutationObserver(addedNode);
+                            let results = addedNode.querySelectorAll('.data.title');
+                            processResults(results);
+                            if (results.length === 150)
+                            {
+                                attachMutationObserver(addedNode);
+                            }
+                            observer.disconnect();
                             return true;
                         }
                     });

--- a/MAL_English_Titles.user.js
+++ b/MAL_English_Titles.user.js
@@ -96,9 +96,10 @@ function translate()
     {
         let type = location.href.substring(24, 29);
         let results = document.getElementsByClassName('data title');
-        for (let i = 0; i < results.length; i++)
+
+        const processResults = function(results)
         {
-            if (!document.getElementById(type + i))
+            for (let i = 0; i < results.length; i++)
             {
                 let url = results[i].children[0].href;
                 let urlShort = url.slice(23);
@@ -107,6 +108,28 @@ function translate()
                 let selector = '.data.title > a[href="' + urlShortDecoded + '"]';
                 addTranslation(type, i, url, id, selector);
             }
+        };
+
+        processResults(results);
+
+        let listTable = document.querySelector('table');
+        if (listTable)
+        {
+            new MutationObserver(function(mutationsList)
+            {
+                mutationsList.forEach(function(mutation)
+                {
+                    processResults(
+                        Array.from(
+                            mutation.addedNodes,
+                            (addedNode) => addedNode.children[0].children[3]
+                        )
+                    );
+                });
+            }).observe(
+                listTable,
+                {childList: true}
+            );
         }
     }
 
@@ -592,25 +615,6 @@ if (!storedManga)
 {
     GM_setValue('manga',{});
     storedManga = {};
-}
-
-// Detect AJAX calls upon infinite scroll, and load new translations
-if (location.href.includes('https://myanimelist.net/animelist') || location.href.includes('https://myanimelist.net/mangalist'))
-{
-    (function(open)
-    {
-        XMLHttpRequest.prototype.open = function()
-        {
-            this.addEventListener("readystatechange", function()
-            {
-                if (this.readyState === 4 && this.status === 200 && (this.responseURL.startsWith('https://myanimelist.net/animelist') || this.responseURL.startsWith('https://myanimelist.net/mangalist')))
-                {
-                    translate();
-                }
-            }, false);
-            open.apply(this, arguments);
-        };
-    })(XMLHttpRequest.prototype.open);
 }
 
 // Launch actual script


### PR DESCRIPTION
This PR fixes #6.

It does so by using a MutationObserver to watch for new elements being added to the list, translating them as they appear. One nice thing that comes from this is that we no longer need to call the entire `translate` function when new titles need translating, meaning we no longer need to loop over entries that have already been translated.

I also combined the anime list and manga list pages since they were basically the same.