### PR TITLE
[Suggestion] Force preffered styling

### DIFF
--- a/MAL_English_Titles.user.js
+++ b/MAL_English_Titles.user.js
@@ -499,7 +499,7 @@ function addTranslation(type, count, url, id, selector, parent=false, tile=false
     let styleIdEnd = ""
     if (tile)
     {
-        styleId = '<h3 class="h3_anime_subtitle" id="' + type + count + '">';
+        styleId = '<h3 class="h3_anime_subtitle" id="' + type + count + '" style="font-weight: bold !important; color: black !important;">';
         styleIdEnd = '</h3>';
     }
     else


### PR DESCRIPTION
Using !important rule in CSS is used to add more importance to a property/value than normal, in this it allows us the make the English title look consistent on all pages.

Im aware you said its not critical and fine as is, but thought Id share findings after working with CSS for another project.